### PR TITLE
Fix README instructions and align shape selector

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,15 +46,15 @@ An interactive web-based tool inspired by the note headers used in the Forever â
 
 To run the tool locally:
 
-1. Clone this repository
+1. Clone this repository:
 
    git clone https://github.com/nbinding/forever-header.git
 
-3.	Navigate to the project directory:
+2. Navigate to the project directory:
 
    cd forever-header
 
-3.	Open index.html in your preferred web browser.
+3. Open `index.html` in your preferred web browser.
 
 ## **Built With**
 

--- a/index.html
+++ b/index.html
@@ -396,6 +396,7 @@
       document.addEventListener("DOMContentLoaded", () => {
         const defaultPath = generateSinePath();
         updateShape(defaultPath);
+        document.getElementById("shape-selector").value = "sine";
       });
       document.getElementById("download-image").addEventListener("click", async () => {
         const svgElement = document.getElementById("halftone-svg");


### PR DESCRIPTION
## Summary
- clean up installation steps in README
- sync the shape selector with the default sine shape on load

## Testing
- `npx htmlhint index.html` *(fails: clipPath tags not lowercase)*

------
https://chatgpt.com/codex/tasks/task_e_684892f5647083339b7775cab998ca5a