### PR TITLE
Add comprehensive shape generator tests

### DIFF
--- a/test/shapes.test.js
+++ b/test/shapes.test.js
@@ -13,12 +13,27 @@ const assert = require('assert');
     assert.strictEqual(typeof path, 'string');
     assert.ok(path.startsWith('M'), 'Path should start with M');
     assert.ok(path.endsWith('Z'), 'Path should end with Z');
+    assert.ok(
+      path.includes('L800 200 L0 200 Z'),
+      'Path should close with the final segment'
+    );
+    return path;
   }
 
-  check(generateMountainRangePath);
-  check(generateCirclesPath);
-  check(generateSinePath);
-  check(generateScallopedPath);
+  const mountainPath = check(generateMountainRangePath);
+  assert.ok(mountainPath.startsWith('M0 150'));
+  assert.strictEqual((mountainPath.match(/ L/g) || []).length, 10);
+
+  const circlesPath = check(generateCirclesPath);
+  assert.ok(circlesPath.startsWith('M0 100'));
+  assert.ok(circlesPath.includes('A'), 'Circles path should contain arc commands');
+
+  const sinePath = check(generateSinePath);
+  assert.strictEqual((sinePath.match(/ L/g) || []).length, 42);
+
+  const scallopedPath = check(generateScallopedPath);
+  assert.ok(scallopedPath.startsWith('M0 100'));
+  assert.ok(scallopedPath.includes('A'), 'Scalloped path should contain arc commands');
 
   console.log('All tests passed.');
 })();


### PR DESCRIPTION
## Summary
- extend shape generator unit tests

## Testing
- `node test/shapes.test.js`

------
https://chatgpt.com/codex/tasks/task_e_68489b3adee88333a03f6309bc9e7b55